### PR TITLE
Remove deprecated license specifier from setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[metadata]
+license = GPLv3+
+license_files = LICENSE
+
 [flake8]
 max-line-length = 102
 extend-ignore = E203

--- a/setup.py
+++ b/setup.py
@@ -38,15 +38,12 @@ setup(
     maintainer="Kiwi TCMS",
     maintainer_email="info@kiwitcms.org",
     url="https://github.com/kiwitcms/robotframework-plugin",
-    license="GPLv3+",
     install_requires=REQUIREMENTS,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: GNU General Public License v3"
-        + " or later (GPLv3+)",
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
This PR removes the deprecated `license` argument and classifier from `setup.py` and specifies `license_files` in `setup.cfg` instead, in accordance with https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

This prevents the `SetuptoolsDeprecationWarning: License classifiers are deprecated.` warning during builds.